### PR TITLE
Add unit tests for GraphDiff and GraphPatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ timeline.json
 .DS_Store
 *.env
 *.gpickle
+.coverage

--- a/tests/test_diff_patch.py
+++ b/tests/test_diff_patch.py
@@ -1,0 +1,233 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch, mock_open
+import os
+import sys
+
+root_dir = os.path.dirname(os.path.dirname(__file__))
+src_dir = os.path.join(root_dir, 'src')
+sys.path.insert(0, src_dir)
+
+from graph_diff.GraphDiff import GraphDiff
+from graph_patch.GraphPatch import GraphPatch
+from neo4j_core.neo4j_model import PrimaryNode, ConnectionNode
+
+# ----------------------------------------------------------------------
+# Helper function: Create neomodel Node Mock object for testing
+# ----------------------------------------------------------------------
+
+def create_mock_node(global_id, element_id, entity_type, timestamp, node_class=MagicMock, **kwargs):
+    """Build a node containing relationship managers based on GraphDiff and GraphPatch source code logic"""
+    node = node_class()
+    
+    # Basic attributes
+    node.GlobalId = global_id
+    node.element_id = element_id
+    node.EntityType = entity_type
+    node.timestamp = timestamp
+    
+    # Build __properties__ dict (GraphPatch source code iterates over this dict directly)
+    node.__properties__ = {
+        "GlobalId": global_id,
+        "EntityType": entity_type,
+        "timestamp": timestamp,
+        **kwargs
+    }
+    
+    # Mock relationship managers (neomodel core components)
+    node.relation_to = MagicMock()
+    node.relation_from = MagicMock()
+    node.equivalent_to = MagicMock()
+    
+    # Return empty lists by default to avoid iteration errors when not configured
+    node.relation_to.all.return_value = []
+    node.relation_from.all.return_value = []
+    node.equivalent_to.all.return_value = []
+    node.equivalent_to.filter.return_value = []
+    
+    return node
+
+# ----------------------------------------------------------------------
+# Tests for GraphDiff
+# ----------------------------------------------------------------------
+
+class TestGraphDiff:
+    
+    @pytest.fixture
+    def diff_tool(self):
+        diff = GraphDiff()
+        # Source code calls self.unique_paths in create_equivalence_relations_connection
+        diff.unique_paths = {} 
+        return diff
+
+    def test_create_equivalence_relations_primary(self, diff_tool):
+        """Test recursive equivalence logic for PrimaryNode: establish connection when attributes and structure perfectly match"""
+        init_node = create_mock_node("P1", "e1", "IfcWall", "v1")
+        updt_node = create_mock_node("P1", "e2", "IfcWall", "v2")
+        
+        child_init = create_mock_node("C1", "e3", "IfcPropertySet", "v1")
+        child_updt = create_mock_node("C1", "e4", "IfcPropertySet", "v2")
+        
+        init_node.relation_to.all.return_value = [child_init]
+        updt_node.relation_to.all.return_value = [child_updt]
+        
+        # Mock rel_init and rel_updt from source code
+        mock_rel_init = MagicMock(rel_type="IsDefinedBy", list_index=0)
+        mock_rel_updt = MagicMock(rel_type="IsDefinedBy", list_index=0)
+        init_node.relation_to.relationship.return_value = mock_rel_init
+        updt_node.relation_to.relationship.return_value = mock_rel_updt
+        
+        diff_tool.create_equivalence_relations_primary(init_node, updt_node)
+        
+        # Verify equivalent_to.connect is called between child nodes
+        child_init.equivalent_to.connect.assert_called_once_with(child_updt)
+
+    def test_create_equivalence_relations_connection_global_id(self, diff_tool):
+        """Test fast matching for ConnectionNode with identical GlobalId"""
+        conn_init = create_mock_node("Rel_1", "c1", "IfcRelConnects", "v1")
+        conn_updt = create_mock_node("Rel_1", "c2", "IfcRelConnects", "v2")
+        
+        diff_tool.create_equivalence_relations_connection(conn_init, conn_updt)
+        conn_init.equivalent_to.connect.assert_called_once_with(conn_updt)
+
+    @pytest.mark.xfail(reason="Source code bug: tries to read GlobalId when it doesn't exist in IoU branch")
+    def test_create_equivalence_relations_connection_iou(self, diff_tool):
+        """Test IoU (Intersection over Union) matching logic for ConnectionNode without GlobalId"""
+        conn_init = create_mock_node(None, "c1", "IfcRelConnects", "v1")
+        conn_updt = create_mock_node(None, "c2", "IfcRelConnects", "v2")
+        
+        # Remove GlobalId attribute to force entering the IoU calculation branch
+        del conn_init.GlobalId
+        del conn_updt.GlobalId
+        
+        child_init = create_mock_node("w1", "e1", "IfcWall", "v1")
+        child_updt = create_mock_node("w1", "e2", "IfcWall", "v2")
+        
+        conn_init.relation_to.all.return_value = [child_init]
+        conn_updt.relation_to.all.return_value = [child_updt]
+        
+        # Mock condition for common_children_count += 1: child_init can find child_updt as equivalent node
+        child_init.equivalent_to.relationship.return_value = MagicMock()
+        
+        diff_tool.create_equivalence_relations_connection(conn_init, conn_updt)
+        
+        # IoU calculates to 1.0, verify equivalent connection is established and unique_paths are recorded
+        conn_init.equivalent_to.connect.assert_called_once_with(conn_updt)
+
+        assert "c1" in diff_tool.unique_paths
+        assert "c2" in diff_tool.unique_paths
+
+    @patch('graph_diff.GraphDiff.Node')
+    @patch('graph_diff.GraphDiff.PrimaryNode')
+    @patch('graph_diff.GraphDiff.ConnectionNode')
+    def test_run_diff(self, mock_conn, mock_primary, mock_node, diff_tool):
+        """Test the entry call for the full Diff pipeline"""
+        proj_init = create_mock_node("proj1", "p1", "IfcProject", "v1")
+        proj_updt = create_mock_node("proj1", "p2", "IfcProject", "v2")
+        mock_node.nodes.get.side_effect = [proj_init, proj_updt]
+        
+        mock_primary.nodes.filter.return_value = []
+        mock_conn.nodes.filter.return_value = []
+        
+        diff_tool.run_diff("v1", "v2")
+        proj_init.equivalent_to.connect.assert_called_once_with(proj_updt)
+
+# ----------------------------------------------------------------------
+# Tests for GraphPatch
+# ----------------------------------------------------------------------
+
+class TestGraphPatch:
+    
+    @pytest.fixture
+    def patch_tool(self):
+        patch = GraphPatch()
+        patch.node_ids_to_unique_paths_mapping = {"v1": {}, "v2": {}}
+        patch.init_side_node_ids_to_unique_paths_mapping = {"v1": {}, "v2": {}}
+        patch.topological_patch_pattern = {"v1": {}, "v2": {}}
+        patch.semantic_patch_pattern = {}
+        patch.nodes_to_delete = []
+        return patch
+
+    @patch('graph_patch.GraphPatch.DataHandler')
+    def test_create_unique_path_mappings(self, mock_data_handler, patch_tool):
+        """Verify recursive generation logic for unique node paths"""
+        mock_data_handler.path_to_string.return_value = "mock_path_string"
+        
+        node = create_mock_node("Global_1", "e1", "IfcWall", "v1")
+        # Force masquerade the node as a PrimaryNode instance to enter the corresponding path reset branch
+        node.__class__ = PrimaryNode 
+        
+        patch_tool.create_unique_path_mappings(node, "v1")
+        
+        # Verify the converted string path is correctly stored in the dict
+        assert "e1" in patch_tool.node_ids_to_unique_paths_mapping["v1"]
+        assert patch_tool.node_ids_to_unique_paths_mapping["v1"]["e1"] == "mock_path_string"
+
+    def test_create_semantic_patch_pattern(self, patch_tool):
+        """Verify correct generation of semantic difference patches when modifying node attributes"""
+        node_init = create_mock_node("P1", "e1", "IfcWall", "v1", Name="Wall A")
+        node_updt = create_mock_node("P1", "e2", "IfcWall", "v2", Name="Wall B")
+        
+        # Remove element_id_property to prevent interception
+        node_init.__properties__.pop("element_id_property", None)
+        node_init.equivalent_to.all.return_value = [node_updt]
+        
+        path_string = "path_to_wall"
+        patch_tool.node_ids_to_unique_paths_mapping["v1"]["e1"] = path_string
+        
+        patch_tool.create_semantic_patch_pattern([node_init], "v1", "v2")
+        
+        assert path_string in patch_tool.semantic_patch_pattern
+        assert patch_tool.semantic_patch_pattern[path_string]["Name"]["v1"] == "Wall A"
+        assert patch_tool.semantic_patch_pattern[path_string]["Name"]["v2"] == "Wall B"
+
+    def test_create_topological_patch_pattern(self, patch_tool):
+        """Verify serialization extraction of new nodes (pushout) and their topological context"""
+        pushout_node = create_mock_node("P2", "e3", "IfcDoor", "v2")
+        pushout_node.timestamp = "v2"
+        
+        # Mock an adjacent node without equivalent nodes (purely newly added) as relation_to
+        adjacent_new = create_mock_node("P3", "e4", "IfcProperty", "v2")
+        adjacent_new.equivalent_to.all.return_value = []
+        
+        # Mock an adjacent node with an equivalent node as context_to
+        adjacent_context = create_mock_node("P4", "e5", "IfcWall", "v2")
+        adjacent_context.equivalent_to.all.return_value = [True]
+        patch_tool.node_ids_to_unique_paths_mapping["v2"]["e5"] = "context_path"
+        
+        pushout_node.relation_to.all.return_value = [adjacent_new, adjacent_context]
+        
+        # Mock relationship attribute extraction
+        mock_rel = MagicMock()
+        mock_rel.__properties__ = {"rel_type": "FillsVoid", "list_index": 0}
+        pushout_node.relation_to.relationship.return_value = mock_rel
+        
+        patch_tool.create_topological_patch_pattern([pushout_node], "v2")
+        
+        # Verify the structure of the result dictionary
+        pattern = patch_tool.topological_patch_pattern["v2"]["e3"]
+        assert pattern["node_type"] == "MagicMock"
+        assert "e4" in pattern["relation_to"]
+        assert "e5" in pattern["context_to"]
+        assert pattern["context_to"]["e5"]["path"] == "context_path"
+
+    @patch('graph_patch.GraphPatch.os.makedirs')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('graph_patch.GraphPatch.Node')
+    @patch('graph_patch.GraphPatch.PrimaryNode')
+    @patch('graph_patch.GraphPatch.ConnectionNode')
+    def test_create_patch_pipeline(self, mock_conn, mock_primary, mock_node, mock_file, mock_makedirs, patch_tool):
+        """Test the complete Patch generation lifecycle and JSON writing"""
+        # Simplify querysets to directly verify the pipeline runs smoothly
+        mock_primary.nodes.filter.return_value = []
+        mock_conn.nodes.filter.return_value = []
+        
+        # Mock Node.nodes.filter(timestamp=...).has(equivalent_to=False).all()
+        mock_filter_qs = MagicMock()
+        mock_filter_qs.has.return_value.all.return_value = []
+        mock_node.nodes.filter.return_value = mock_filter_qs
+        
+        patch_tool.create_patch("Proj1", "v1", "v2")
+        
+        mock_makedirs.assert_called_with("patch_data", exist_ok=True)
+        assert mock_file.call_count == 2


### PR DESCRIPTION
Note on a discovered bug in GraphDiff.py -> create_equivalence_relations_connection. 

When nodes fall into the IoU calculation branch (which happens specifically because they lack a GlobalId), the code still attempts to read connection_node_init.GlobalId to store it in unique_paths, causing an AttributeError.

I kept the source code untouched for now and marked the test as an expected failure so the pipeline won't break. We'll need to add a safe check (hasattr) in the source code later.